### PR TITLE
Display warning when citing in a doc with 100+ pages

### DIFF
--- a/src/connector/clientAppsScript.js
+++ b/src/connector/clientAppsScript.js
@@ -55,7 +55,8 @@ Zotero.GoogleDocs.ClientAppsScript.prototype = {
 	call: async function(request) {
 		var method = request.command.split('.')[1];
 		var args = Array.from(request.arguments);
-		var docID = args.splice(0, 1);
+		// Splicing off the docID that we don't need to pass as an arg to the method
+		var _docID = args.splice(0, 1);
 		var result;
 		try {
 			result = await this[method].apply(this, args);

--- a/src/connector/googleDocs.js
+++ b/src/connector/googleDocs.js
@@ -85,6 +85,11 @@ Zotero.GoogleDocs = {
 		if (!client) {
 			client = new Zotero.GoogleDocs.Client();
 			await client.init();
+			const shouldContinue = await Zotero.GoogleDocs.UI.warnIfLargeDoc(client.documentID);
+			if (!shouldContinue) {
+				Zotero.debug('User cancelled the request in the large document warning');
+				return;
+			}
 		}
 
 		if (command == 'addEditCitation') {
@@ -116,6 +121,11 @@ Zotero.GoogleDocs = {
 		// Use the last client with a cached field list to speed up the cursorInField() lookup
 		var client = this.lastClient || new Zotero.GoogleDocs.Client();
 		await client.init();
+		const shouldContinue = await Zotero.GoogleDocs.UI.warnIfLargeDoc(client.documentID);
+		if (!shouldContinue) {
+			Zotero.debug('User cancelled the request in the large document warning');
+			return;
+		}
 		try {
 			var field = await client.cursorInField(true);
 		} catch (e) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d48a9e14-8de5-4def-a5d6-7d2b08d36183)

Closes #79 

@dstillman you may want to tweak the strings https://github.com/zotero/zotero-connectors/commit/2de1fbbd039c1cb39ad0b05b1eed36e371e82a31 but otherwise I'll just merge this since it's better to have something like this than to have users come to us when they are at 300 pages and have serious problems.