### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/src/apps-script/Code.js
+++ b/src/apps-script/Code.js
@@ -349,7 +349,7 @@ exposed.footnotesToInline = function(fieldIDs) {
 		var textEl = footnoteSection.editAsText();
 		var url = textEl.getLinkUrl(1);
 		// First footnote character is usually a space, but if the second one is not a link
-		// then we assume the footnote isn't a convertable Zotero field
+		// then we assume the footnote isn't a convertible Zotero field
 		if (!url) return;
 		var key = url.substr(config.fieldURL.length, config.fieldKeyLength);
 		var field = fieldMapping[key];
@@ -631,7 +631,7 @@ exposed.importDocument = function() {
 exposed.clearAllFields = function() {
 	var start = Date.now();
 	var fields = getFields();
-	for (var i = 0; i < fields.lenght; i++) {
+	for (var i = 0; i < fields.length; i++) {
 		var field = fields[i];
 		// Not calling field.unlink(), since that removes the link
 		field.namedRanges.forEach(function(namedRange) {

--- a/src/connector/client.js
+++ b/src/connector/client.js
@@ -309,7 +309,7 @@ Zotero.GoogleDocs.Client.prototype = {
 	},
 
 	setCode: async function(fieldID, code) {
-		// The speed of updates is highly dependend on the size of
+		// The speed of updates is highly dependent on the size of
 		// field codes. There are a few citation styles that require
 		// the abstract field, but they are not many and the speed
 		// improvement is worth the sacrifice. The users who need to

--- a/src/connector/clientAppsScript.js
+++ b/src/connector/clientAppsScript.js
@@ -537,7 +537,7 @@ Zotero.GoogleDocs.ClientAppsScript.prototype = {
 		if (!(fieldID in this.queued.fields)) {
 			this.queued.fields[fieldID] = {id: fieldID};
 		}
-		// The speed of updates is highly dependend on the size of
+		// The speed of updates is highly dependent on the size of
 		// field codes. There are a few citation styles that require
 		// the abstract field, but they are not many and the speed
 		// improvement is worth the sacrifice. The users who need to

--- a/src/connector/document.js
+++ b/src/connector/document.js
@@ -810,7 +810,7 @@ let Field = Zotero.GoogleDocs.Field = class {
 				link: { url: config.fieldURL + this.id }
 			};
 			// Insertions via API default to surrounding text paragraph style including font-size, unless
-			// manually overriden. We pick up the custom set font-size for the current text run here.
+			// manually overridden. We pick up the custom set font-size for the current text run here.
 			if (localFontSize) {
 				textStyle.fontSize = localFontSize;
 			}

--- a/src/connector/ui.jsx
+++ b/src/connector/ui.jsx
@@ -245,7 +245,7 @@ Zotero.GoogleDocs.UI = {
 					let linkRanges = ranges[linkStart].nrs_ei.cv.opValue
 					// `&& key in keysToCode` is kinda strange
 					// since we have just grabbed all the named ranges above from doc slices
-					// but we get reports of copy pasting failing occassionally
+					// but we get reports of copy pasting failing occasionally
 					// and finally got a reproducible case:
 					// https://forums.zotero.org/discussion/80427/
 						.filter(key => !ignoreKeys.has(key) && key in keysToCodes)


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

Funny enough it even fixed a bug!