### PR TITLE
Fix F character sometimes appearing on footnote creation

### DIFF
--- a/src/connector/ui.jsx
+++ b/src/connector/ui.jsx
@@ -545,7 +545,7 @@ Zotero.GoogleDocs.UI = {
 		await Zotero.Promise.delay();
 	},
 	
-	sendKeyboardEvent: async function(eventDescription, target) {
+	sendKeyboardEvent: async function(eventDescription, target, skipKeypress) {
 		if (!target) {
 			target = document.querySelector('.docs-texteventtarget-iframe').contentDocument;
 			
@@ -555,7 +555,10 @@ Zotero.GoogleDocs.UI = {
 			target.dispatchEvent(new KeyboardEvent('keydown', eventDescription));
 			await Zotero.Promise.delay();
 			target.dispatchEvent(new KeyboardEvent('keyup', eventDescription));
-			target.dispatchEvent(new KeyboardEvent('keypress', eventDescription));
+			// Skip keypress event if explicitly specified
+			if (!skipKeypress) {
+				target.dispatchEvent(new KeyboardEvent('keypress', eventDescription));
+			}
 			await Zotero.Promise.delay();
 			return;
 		}
@@ -639,12 +642,14 @@ Zotero.GoogleDocs.UI = {
 		if (Zotero.isMac) {
 			insertFootnoteKbEvent = {metaKey: true, altKey: true, key: 'f', keyCode: 70};
 		}
-		await Zotero.GoogleDocs.UI.sendKeyboardEvent(insertFootnoteKbEvent);
-		// Somehow the simulated footnote shortcut inserts an "F" at the start of the footnote.
-		// But not on a mac. Why? Why not on a Mac?
-		if (!Zotero.isMac) {
-			await Zotero.GoogleDocs.UI.sendKeyboardEvent({key: "Backspace", keyCode: 8});
-		}
+		// Sometimes, on Windows and Linux (but not macOS), dispatching `keypress` event leads
+		// to an unwanted "F" character inserted into the footnote.
+		// `keypress` is not necessary to trigger shortcuts, so send `keyup` and `keydown` events only.
+		await Zotero.GoogleDocs.UI.sendKeyboardEvent(insertFootnoteKbEvent, null, true);
+		// Ensure the cursor is moved past the first whitespace, so that it ends up on a Zotero link.
+		// Otherwise, it would not be handled by moveCursorToEndOfCitation, and cursor would remain
+		// at the very beginning of the footnote.
+		await Zotero.GoogleDocs.UI.sendKeyboardEvent({ key: "ArrowRight", keyCode: 39 }, null, true);
 	},
 	
 	insertLink: async function(text, url) {


### PR DESCRIPTION
https://forums.zotero.org/discussion/130080/bug-report-anomalous-character-in-automatic-google-docs-citations

Inserting a citation in a footnote would sometimes insert "F" character before the actual citation. Reproduced on Windows 11 VM in Firefox and Chrome. "F" is expected to be inserted, but it is supposed to be removed via a subsequent Backspace event - this is what would fail to happen.

Tracked down the actual insertion of "F" to the `keypress` event emitted in `Zotero.GoogleDocs.UI.sendKeyboardEvent` from `insertFootnote`. For example, emitting a `keypress` event with a different character would insert that other character instead of "F".

As a solution, added an optional flag to `Zotero.GoogleDocs.UI.sendKeyboardEvent` to not emit the `keypress` event at all. It is used in `insertFootnote` to avoid printing the "F", which means it does not need to be subsequently deleted via backspace. It does not affect other instances where `sendKeyboardEvent` is used.

Another tweak that helped to not print the "F" character is to emit Backspace event twice - but that felt much less reliable.

---

In this [demo](https://www.dropbox.com/scl/fi/rq5qlbbxwruoduvp0pinl/gDocs_fixed_f_demo.mov?rlkey=umhhvh9pdrmkj746g1wsubvh6&st=y0az4znp&dl=0), I add citation in firefox with the current connector. Note the text initially inserted into the footnote is "F {Updating}". Then, I load the connector build with this update and try again. Note "F" no longer appears. I tested this on Firefox and Chrome on Mac, Linux and Windows.